### PR TITLE
match parameters to actual repository ones

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -1,13 +1,13 @@
-PROJECT_NAME=dead_songs
+PROJECT_NAME=transportation_systems_2018
 
 # the database superuser name - this is the default
 POSTGRES_USER=postgres
 
 # the database name the API will connect to - "dbname" in most PostgreSQL command-line tools
-POSTGRES_NAME=dead_songs
+POSTGRES_NAME=transportation-systems-main
 
 # the database owner - automatic restore needs this (most likely only used in dev)
-DATABASE_OWNER=sampleuser
+DATABASE_OWNER=transportation-systems
 
 # *service* name (*not* image name) of the database in the Docker network
 POSTGRES_HOST=db_development


### PR DESCRIPTION
The project, database name and database user in `env.sample` don't match the correct values in the repository. This PR fixes that.