### PR TITLE
Fix DEBUG across projects

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -1,5 +1,8 @@
 PROJECT_NAME=transportation_systems_2018
 
+# Set the default for development
+DEBUG=True
+
 # the database superuser name - this is the default
 POSTGRES_USER=postgres
 

--- a/transportation_systems_2018/settings.py
+++ b/transportation_systems_2018/settings.py
@@ -23,11 +23,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-
-if os.environ.get('DEBUG')=='True':
-    DEBUG=True
-else:
-    DEBUG=False
+DEBUG = bool(os.environ.get('DEBUG', False))
 
 
 ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
Setting DEBUG off in Production across projects:
https://github.com/hackoregon/civic-devops/issues/139

And using the technique suggested by Hassan to set it cleanly:
https://github.com/hackoregon/neighborhoods-2018/pull/27/files/69f27184cd6cf2a994be072b1f5482d136a5fd96

The only change to local development that should be necessary is to ensure all developers have `DEBUG = True` in their environment variables (or `.env` file, or however they're managing environment).