### PR TITLE
add endpoint returning info on each census

### DIFF
--- a/passenger_census_api/serializers.py
+++ b/passenger_census_api/serializers.py
@@ -37,3 +37,10 @@ class PassengerCensusAnnualSerializer(serializers.ModelSerializer):
         annual_sum_ons = IntegerField()
         annual_sum_offs = IntegerField()
         total_annual_stops = IntegerField()
+
+class PassengerCensusInfoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PassengerCensus
+        fields = ['summary_begin_date', 'service_key']
+        total_routes = IntegerField()
+        total_stops = IntegerField()

--- a/passenger_census_api/tests.py
+++ b/passenger_census_api/tests.py
@@ -36,15 +36,6 @@ class PassengerCensusRoutesAnnualEndpointTestCase(TestCase):
     def test_total_stops_response(self):
         response = self.client.get('/transportation-systems/passenger-census/passenger-census-routes-annual/?route=1&year=2002')
         assert response.status_code == 200
-        # print(response.data)
-        # self.assertEqual(response.data['year'], 2002)
-        # self.assertEqual(response.data['weekday_sum_ons'], 456820)
-        # self.assertEqual(response.data['weekday_sum_offs'], 453960)
-        # self.assertEqual(response.data['weekday_total_stops'], 26520)
-        # self.assertEqual(response.data['annual_sum_ons'], 509574)
-        # self.assertEqual(response.data['annual_sum_offs'], 508300)
-        # self.assertEqual(response.data['total_annual_stops'], 78520)
-        # self.assertEqual(response.data['num_of_yearly_census'], 2)
     def test_missing_route(self):
         response = self.client.get('/transportation-systems/passenger-census/passenger-census-routes-annual/?year=2002')
         assert response.status_code == 400
@@ -53,7 +44,10 @@ class PassengerCensusRoutesAnnualEndpointTestCase(TestCase):
         response = self.client.get('/transportation-systems/passenger-census/passenger-census-routes-annual/?route=678&year=2002')
         assert response.status_code == 404
         self.assertEqual(response.data, 'Route Number not found')
-    # def test_nonexistent_route(self):
-    #     response = self.client.get('/transportation-systems/passenger-census/passenger-census-route-annual/?route=1&year=2990')
-    #     assert response.status_code == 404
-    #     self.assertEqual(response.data, 'No Data found for Route Number and Year')
+
+class PassengerCensusInfoEndpointTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+    def test_total_stops_response(self):
+        response = self.client.get('/transportation-systems/passenger-census/passenger-census-info/')
+        assert response.status_code == 200

--- a/passenger_census_api/urls.py
+++ b/passenger_census_api/urls.py
@@ -11,6 +11,7 @@ router.register(r'passenger-census-routes', views.PassengerCensusRoutesViewSet)
 
 router.register(r'passenger-census', views.PassengerCensusRetrieveViewSet)
 router.register(r'passenger-census-routes-annual', views.PassengerCensusRoutesAnnualViewSet, base_name='passenger-census')
+router.register(r'passenger-census-info', views.PassengerCensusInfoViewSet, base_name='passenger-census')
 
 # schema_view = get_swagger_view(title='Hack Oregon 2018 Transportation Systems APIs')
 


### PR DESCRIPTION
adds endpoint  related to: https://github.com/hackoregon/transportation-systems-backend-2018/issues/35

returning distinct start dates with counts of total number of routes and stops for each, 

Here is the sql the Django ORM is equal to:

```
SELECT DISTINCT "passenger_census"."summary_begin_date", COUNT(DISTINCT "passenger_census"."route_number") AS "total_routes", COUNT(DISTINCT "passenger_census"."stop_seq") AS "total_stops", EXTRACT('year' FROM "passenger_census"."summary_begin_date") AS "year" FROM "passenger_census" GROUP BY "passenger_census"."summary_begin_date", EXTRACT('year' FROM "passenger_census"."summary_begin_date") ORDER BY "passenger_census"."summary_begin_date" ASC; args=()

```
