### PR TITLE
remove broken apt package dependency postgresql-9.6-postgis-scripts in...

### DIFF
--- a/DOCKERFILE.db.development
+++ b/DOCKERFILE.db.development
@@ -7,7 +7,6 @@ RUN apt-get update \
     postgis \
     postgresql-9.6-postgis-2.4 \
     postgresql-9.6-postgis-2.4-scripts \
-    postgresql-9.6-postgis-scripts \
     postgresql-9.6-pgrouting \
   && apt-get clean
 


### PR DESCRIPTION
...DOCKERFILE.db.development to fix development DB docker image

Fixers #120 