### PR TITLE
Getpackages

### DIFF
--- a/civic_sandbox/packages.py
+++ b/civic_sandbox/packages.py
@@ -1,0 +1,42 @@
+packages = {   
+  'Transportation': {
+    'description': '',
+    #'Transporation Package',
+    'foundations' : ['042'],
+    'default_foundation' : '042',
+    'slides' : ['031', '032', '015'],
+    'default_slide' : ['031', '032', '015',]
+    },
+}
+
+slides = {
+  '015': {
+    'name': 'Change in Ridership by Route',
+    'endpoint':'http://service.civicpdx.org/transportation-systems/sandbox/slides/routechange/',
+    'visualization': 'PathMap',
+  },
+  '031': {
+    'name': 'Safety Hotline',
+    'endpoint':'http://service.civicpdx.org/transportation-systems/sandbox/slides/safetyhotline/',
+    'visualization': 'ScatterPlotMap',
+  },
+  '032': {
+    'name': 'Crashes',
+    'endpoint':'http://service.civicpdx.org/transportation-systems/sandbox/slides/crashes/',
+    'visualization': 'ScatterPlotMap',
+  },
+}
+
+foundations = {
+  '042': {
+    'name': 'Change in Ridership by Census Block',
+    'endpoint':'http://service.civicpdx.org/transportation-systems/sandbox/foundations/blockchange/',
+    'visualization': 'ChoroplethMap',
+  },
+}
+
+package_info = {
+    'packages' : packages,
+    'slides' : slides,
+    'foundations' : foundations
+    }

--- a/civic_sandbox/packages_view.py
+++ b/civic_sandbox/packages_view.py
@@ -1,0 +1,5 @@
+from django.http import JsonResponse
+from civic_sandbox import packages
+
+def packages_view(request):
+    return JsonResponse(packages.package_info)

--- a/civic_sandbox/urls.py
+++ b/civic_sandbox/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 from rest_framework.urlpatterns import format_suffix_patterns
 from . import views
+from civic_sandbox import packages_view
 
 urlpatterns = [
     url(r'^slides/safetyhotline/(?P<date_filter>\d+)', views.safetyhotline),
@@ -10,5 +11,6 @@ urlpatterns = [
     url(r'^slides/routechange/', views.routechange),
     url(r'^foundations/blockchange/', views.blockchange),
     url(r'^slides/sensors/', views.sensors),
+    url(r'^package_info/', packages_view.packages_view, name='package_info'),
 ]
 urlpatterns = format_suffix_patterns(urlpatterns)


### PR DESCRIPTION
This PR supports de-centralizing the package definitions from a monolithic central list in the [civic-sandbox](https://github.com/hackoregon/civic-sandbox) [lamba_function](https://github.com/hackoregon/civic-sandbox/blob/4e1a89f31230b13584d41e7bfca6f158f0f90841/lambda_function.py#L33) to distributing them to each respective backend repo. Specifically it moves the transportation-systems package definitions from being contained inside the monolithic dictionary in the [lamba_function](https://github.com/hackoregon/civic-sandbox/blob/4e1a89f31230b13584d41e7bfca6f158f0f90841/lambda_function.py#L33) source code to a file defined in this repo and served from a endpoint exposed from this backend, using a canonical data format and endpoint url scheme.

Contained in this PR are three items:

1. The package definition data is contained in a file called [package_info.py](https://github.com/hackoregon/transportation-systems-backend-2018/blob/getpackages/civic_sandbox/packages_view.py) containing three dictionaries: slides, foundations, and packages (this dictionary/JSON encoding format was not changed from the original format defined in the civic_sandbox repo) 

2. A view, [packages_view[(https://github.com/hackoregon/transportation-systems-backend-2018/blob/getpackages/civic_sandbox/packages_view.py) that serves the package definition data by encoding the data in the `package_info.py` into JSON.

3. [A URL exposing the `packages_view` using a canonical and easily-discoverable scheme.](https://github.com/hackoregon/transportation-systems-backend-2018/blob/683d4f2792ab07fcf0f18bc208ad2c25126f41ae/civic_sandbox/urls.py#L14)

Using these three simple and small mechanisms allows this repo to serve, as well as easily update and deploy, its own package definitions in an easily-discoverable and implementable manner.