### PR TITLE
address reported security vulnerabilities

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,11 +1,11 @@
 # Django
-Django==2.0.2
+Django==2.0.11
 django-extensions==1.9.9
 itypes==1.1.0
 packaging==16.8
 django-cors-headers==1.2.0
 pyparsing==2.2.0
-requests==2.18.4
+requests==2.20.0
 simplejson==3.13.2
 six==1.11.0
 uritemplate==3.0.0


### PR DESCRIPTION
Require 

- django==2.0.11
- requests==2.20.0

to fix reported security vulnerabilities.